### PR TITLE
Disables page scroll. Fixes #2

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -9,6 +9,7 @@
 
 body {
   background: rgb(25, 25, 25);
+  overflow: hidden;
 }
 
 #game {


### PR DESCRIPTION
Since this is a full-page web app, we should set overflowed content to hidden anyway.